### PR TITLE
clean up end_loop_signal logic

### DIFF
--- a/lib/aws_logs/tail.rb
+++ b/lib/aws_logs/tail.rb
@@ -41,7 +41,7 @@ module AwsLogs
         display
         since, now = now, current_now
         loop_count!
-        sleep 5 if @follow && !@@end_loop_signal && !ENV["AWS_LOGS_TEST"]
+        sleep 5 if @follow && !ENV["AWS_LOGS_TEST"]
       end
       # Refresh and display a final time in case the end_loop gets interrupted by stop_follow!
       refresh_events(since, now)
@@ -100,9 +100,7 @@ module AwsLogs
       return unless follow_until
 
       messages = @events.map(&:message)
-      if messages.detect { |m| m.include?(follow_until) }
-        @@end_loop_signal = true
-      end
+      @@end_loop_signal = messages.detect { |m| m.include?(follow_until) }
     end
 
     def say(text)
@@ -113,15 +111,14 @@ module AwsLogs
       @output.join("\n") + "\n"
     end
 
-    @@end_loop_signal = false
     def set_trap
       Signal.trap("INT") {
         puts "\nCtrl-C detected. Exiting..."
-        @@end_loop_signal = true  # useful to control loop
         exit # immediate exit
       }
     end
 
+    @@end_loop_signal = false
     def self.stop_follow!
       @@end_loop_signal = true
     end


### PR DESCRIPTION
Edge cases:

* When `stop_follow!` is called from another Rub program, will wait until the last loop iteration finishes and provide up to another 5 seconds to receive logs.
* There's already a final `refresh_events` and `display` also. That generally helps send the more of the last of the logs.